### PR TITLE
Fix stopTol type in Geo median filter Mex wrapper

### DIFF
--- a/filters/CMF_medfiltGeoRN2DMex.cpp
+++ b/filters/CMF_medfiltGeoRN2DMex.cpp
@@ -20,7 +20,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     int RD = (int)mxGetScalar(rIn);
     int TD = (int)mxGetScalar(tIn);
     int nIter = (int)mxGetScalar(nIterIn);
-    double stopTol = (int)mxGetScalar(stopTolIn);
+    double stopTol = mxGetScalar(stopTolIn);
     int nDimNum = mxGetNumberOfDimensions(yIn);
     const int* pDims = mxGetDimensions(yIn);
     double* y = mxGetPr(yIn);


### PR DESCRIPTION
## Summary
- fix incorrect cast in `CMF_medfiltGeoRN2DMex.cpp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4c68144c8320a37c1ae495d9c48a