### PR TITLE
Fix v0.1.7 publish: pin cibuildwheel to matrix Python

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,23 +45,28 @@ jobs:
       - name: Build Wheels
         env:
           CXXFLAGS: "-std=c++11"
-          # i686 dropped: no meaningful Linux desktop install base in 2026,
-          # and it doubled wheelhouse contents (the non-precise glob in the
-          # test step below used to pick an i686 wheel on the x86_64 runner).
+          # i686 dropped: no meaningful Linux desktop install base in 2026.
           CIBW_SKIP: "pypy* *i686*"
-          CIBW_BUILD: "cp*"
-        run: cibuildwheel --output-dir wheelhouse .
+        run: |
+          # Pin cibuildwheel to the matrix Python only (default cp* would
+          # build all 5 Pythons on every runner — same filenames overwrite
+          # each other in download-artifact's merge-multiple, and a flaky
+          # upload from any one of the 5 redundant copies leaves a corrupt
+          # wheel in the merged dist for the publish job's twine check).
+          PYV="${{ matrix.python-version }}"
+          export CIBW_BUILD="cp${PYV//.}-*"
+          cibuildwheel --output-dir wheelhouse .
 
       - name: Run pytest against the built wheel
-        # Linux only: cibuildwheel builds wheels for every cp* Python in the
-        # build set (not just the host's), so we have to glob precisely on
-        # both the matrix Python tag and x86_64. macOS and Windows wheels
-        # are tested implicitly via the post-publish verify step.
+        # Linux only: install the freshly-built wheel via --find-links so
+        # pip picks the best-matching manylinux variant automatically (the
+        # runner produces both manylinux_2_17 and manylinux_2_28 wheels for
+        # the host Python). macOS and Windows wheels are exercised by the
+        # post-publish verify step.
         if: runner.os == 'Linux'
         run: |
           pip install pytest matplotlib Pillow
-          PYTAG=cp$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')
-          pip install --no-deps --force-reinstall wheelhouse/pycirclemedianfilter-*-${PYTAG}-${PYTAG}-manylinux*_x86_64*.whl
+          pip install --no-index --find-links wheelhouse/ --no-deps --force-reinstall pycirclemedianfilter
           pytest tests_py/ -v
 
       - name: Upload Wheels Artifact

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,6 +43,9 @@ jobs:
         run: pip install cibuildwheel
 
       - name: Build Wheels
+        # Force bash on Windows too — PowerShell is the default there and
+        # would reject the parameter expansion below.
+        shell: bash
         env:
           CXXFLAGS: "-std=c++11"
           # i686 dropped: no meaningful Linux desktop install base in 2026.


### PR DESCRIPTION
## Summary

The v0.1.7 tag-push workflow built all 16 wheel jobs cleanly but the **Publish to PyPI** step failed at twine check with `zipfile.BadZipFile: Bad magic number for central directory` on a musllinux wheel. Nothing reached PyPI.

### Root cause

cibuildwheel doesn't honor the host Python — with `CIBW_BUILD: \"cp*\"` every matrix runner builds wheels for **all** five Python versions. Each Linux runner therefore produced the same ~10 wheel filenames; the publish job's `actions/download-artifact` with `merge-multiple: true` then merged the 5 Linux artifacts into a single \`dist/\` directory, overwriting each other in turn. Wheels aren't byte-deterministic (timestamps in the inner zip), so a flaky upload from any one of the 5 redundant copies could leave a corrupt file under the canonical name. That's what twine read.

### Fix

- **Pin `CIBW_BUILD` per matrix entry** to `cp${pyver}-*`. Each runner now produces only its host Python's wheels — no duplicate filenames in the merged dist. Side benefit: ~5× fewer wheels built per Linux runner.
- **Replace the test-step install glob** with `pip install --no-index --find-links wheelhouse/ pycirclemedianfilter`. The runner produces multiple manylinux variants (`manylinux_2_17` + a newer one) for the host Python; pip's resolver picks the best match. Cleaner than a wildcard glob.

## Test plan

- [ ] Linux/macOS/Windows matrix all green; each runner produces wheels for exactly one Python.
- [ ] After merge: move the v0.1.7 tag to the new master tip, force-push, watch publish job succeed at twine check + OIDC upload + the post-publish import-and-call verify.