### PR TITLE
Auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -109,8 +109,12 @@ jobs:
       name: pypi
       url: https://pypi.org/project/pycirclemedianfilter/
     permissions:
-      id-token: write   # required for OIDC trusted publishing
+      id-token: write    # required for OIDC trusted publishing
+      contents: write    # required for the GitHub Release step below
     steps:
+      - name: Checkout (for CHANGELOG.md)
+        uses: actions/checkout@v4
+
       - name: Download all wheels and sdist
         uses: actions/download-artifact@v4
         with:
@@ -123,6 +127,30 @@ jobs:
         # PYPI_API_TOKEN secret is retained in repo settings as a manual
         # fallback (user can `twine upload` from local if OIDC ever breaks).
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Extract release notes from CHANGELOG.md
+        # Pulls the section bounded by `## <version>` and the next `## `.
+        # GITHUB_REF_NAME is "v0.1.7"; CHANGELOG headings are "## 0.1.7 — ...".
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VER" '
+            $0 ~ "^## " ver "( |$)" { found=1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          echo "--- extracted notes ---"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        # Idempotent: if a Release for this tag already exists (e.g. created
+        # manually before this step landed), softprops updates rather than
+        # erroring. Wheels + sdist from dist/ are attached as assets so the
+        # release page mirrors PyPI for users who don't use pip.
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          files: dist/*
 
       - name: Verify uploaded package (real import + filter call)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now auto-creates a GitHub Release on every `v*` tag push** in
+  addition to publishing to PyPI. The publish job extracts the matching
+  `## <version>` section from `CHANGELOG.md` as the release body and
+  attaches all wheels and the sdist as assets. v0.1.7's release entry
+  was created retroactively via `gh release create`.
+
 ## 0.1.7 — 2026-05-07 (maintenance)
 
 A maintenance release fixing two real bugs and bringing CI / packaging


### PR DESCRIPTION
## Summary

Closes the gap that v0.1.7 exposed: pushing a `v*` tag publishes to PyPI, but does **not** create an entry on the GitHub Releases page. v0.1.7's release was created manually via `gh release create` after the fact. From v0.1.8 onward this step is automatic.

## How it works

In the existing `publish` job, after the PyPI upload:

1. `actions/checkout@v4` is added so `CHANGELOG.md` is on disk (`download-artifact` only puts wheels in `dist/`).
2. An awk one-liner extracts the `## <version>` section verbatim — bounded by the heading and the next `## ` — and writes it to `release-notes.md`.
3. `softprops/action-gh-release@v2` creates the Release with that as the body and all of `dist/*` (wheels + sdist) as assets. It updates in place if a Release for the tag already exists, so manual pre-creation never breaks a later run.

`contents: write` is added to the publish job's permissions (required by the release action). `id-token: write` for OIDC stays.

## Test plan

- [ ] Manually verified `awk` extraction against current `CHANGELOG.md` produces the expected v0.1.7 section locally (looks right).
- [ ] First real exercise: next `v*` tag push (presumably v0.1.8 if/when one is needed) should produce both the PyPI upload and a GitHub Release entry mirroring the changelog section, with wheels + sdist attached.
- [ ] Idempotency: re-running the workflow on the same tag should update the Release rather than failing.