### PR TITLE
Harmonise README + drop stale column-major-order warning + clean up demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,100 @@
-# Circle median filter toolbox (CMF)
- 
-This toolbox contains a fast algorithm for median filtering of signals and images with values on the unit circle, for example phase or orientation data.
-The (arc distance) median filter for an image y with values on the unit circle is given by 
+# CircleMedianFilter (CMF) — Fast median filtering for phase or orientation data
+
+[![PyPI](https://img.shields.io/pypi/v/pycirclemedianfilter.svg)](https://pypi.org/project/pycirclemedianfilter/)
+[![Python](https://img.shields.io/pypi/pyversions/pycirclemedianfilter.svg)](https://pypi.org/project/pycirclemedianfilter/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![MATLAB](https://img.shields.io/badge/MATLAB-supported-orange.svg)](#matlab)
+[![View Circle Median Filter on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://de.mathworks.com/matlabcentral/fileexchange/62509-circle-median-filter)
+
+A fast median filter for signals and images whose values lie on the unit circle (phase, orientation, interferometric SAR, wind directions, optical-flow angles). Linear in filter mask size for non-quantised data, constant for quantised data.
+
+![alt tag](https://hci.iwr.uni-heidelberg.de/sites/default/files/publications/teaserimages/1908951751/mediancircularrevision_teaser_small.png)
+
+*Left:* A circle-valued image — every pixel takes its value on the unit circle (or in angular representation a value in (-π, π]), visualised as the hue component in the HSV colour space. *Right:* Effect of the circle-median filter using a 7 × 7 mask.
+
+The (arc distance) median filter for an image y with values on the unit circle is given by
 
 <img src="docs/eqArcDistanceMedian.png" width="40%">
 
 where d denotes the arc distance length of two angles, and r, t are the horizontal and vertical "radii" of the filter mask.
 
-The code is a reference implementation (in C++ with Matlab wrappers) of the algorithms described in the paper:
+## Paper
 
-Martin Storath, Andreas Weinmann.
-[Fast median filtering for phase or orientation data.](https://doi.org/10.1109/TPAMI.2017.2692779)
-IEEE Transactions on Pattern Analysis and Machine Intelligence, 	40(3):639-652, 2018  ([preprint](https://hci.iwr.uni-heidelberg.de/sites/default/files/profiles/mstorath/files/storath2017fast.pdf))
+> M. Storath, A. Weinmann.
+> [*Fast median filtering for phase or orientation data.*](https://doi.org/10.1109/TPAMI.2017.2692779)
+> IEEE Transactions on Pattern Analysis and Machine Intelligence, 40(3):639–652, 2018.
+> [preprint](https://hci.iwr.uni-heidelberg.de/sites/default/files/profiles/mstorath/files/storath2017fast.pdf)
 
-See also [![View Circle Median Filter on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://de.mathworks.com/matlabcentral/fileexchange/62509-circle-median-filter)
+## Quickstart
 
-## Updates
-- 2025/02/18: Added Python bindings for the core C++ filtering code. See installation notes below.
+### Python
 
+```bash
+pip install pycirclemedianfilter
+```
 
+**Important:** The underlying implementation expects *column-major order* arrays — convert with `data = np.asfortranarray(data)` if necessary before calling the filter function. See [`demos_python/`](demos_python/) for examples.
 
-### Example 
+### MATLAB
 
+- Run `CMF_install.m` in the MATLAB console and follow the demos in [`demos_matlab/`](demos_matlab/).
 
-![alt tag](https://hci.iwr.uni-heidelberg.de/sites/default/files/publications/teaserimages/1908951751/mediancircularrevision_teaser_small.png)
+### C++
 
-*Left:* A circle-valued image, i.e. every pixel takes its value on the unit circle (or in angular representation a value in (-pi, pi]). The values are visualized as hue component in the HSV color space.
-*Right:* Effect of the circle-median filter using a filter mask of size 7 × 7. 
+- Compile `CMF_library.cpp`. The relevant functions are `medfiltCirc2D` and `medfiltCirc2DQuant`. Their usage is documented as comments in `CMF_library.cpp`.
 
-### Runtime comparison
+## Runtime comparison
 
-The time complexity w.r.t. the size of the filter mask is
-- linear for non-quantized data
-- constant for quantized data
+Time complexity with respect to filter mask size is
+
+- linear for non-quantised data,
+- constant for quantised data.
 
 <img src="docs/runtime.png" width="80%">
 
-### Applications
+## Applications
 
 - Smoothing of phase data, e.g. interferometric SAR images
-   ![alt tag](docs/InSAR.png)
+
+   ![InSAR](docs/InSAR.png)
+
 - Smoothing of orientation data, e.g. wind directions
 
    <img src="docs/windDirections.png" width="60%">
-   
-- Smoothing of vector fields in polar coordinates, e.g. optical flow images
 
-### Contents
-- demos:     some demos, self explanatory (implemented in Matlab)
-- auxiliary: some useful helper functions (implemented in Matlab)
-- filters:   the fast algorithms for median filtering of circle valued data 
-(implemented in C++ with Matlab wrappers)
+- Smoothing of vector fields in polar coordinates, e.g. optical-flow images.
 
-## Installation and usage 
+## Updates
 
-## Python
-- Installation via ```pip install pycirclemedianfilter```.
-- **Important:** The underlying implementation expects *column-major order* arrays. So convert data by ```data = np.asfortranarray(data)``` if necessary before calling the filter function. See the demos_python folder for examples.
+- 2025/02/18: Added Python bindings for the core C++ filtering code.
 
-## Matlab
-- From Matlab: Run CMF_install.m in the Matlab console and follow the demos 
-- From C++: Compile CMF_library.cpp. The relevant functions are medfiltCirc2D and medfiltCirc2DQuant. Their usage is described as comment in the CMF_library.cpp file.
+## Contents
 
+- `demos_matlab/` — MATLAB demos
+- `demos_python/` — Python demos
+- `auxiliary/` — helper functions (MATLAB)
+- `filters/` — the fast algorithms for median filtering of circle-valued data (C++ with MATLAB wrappers)
 
+## How to cite
 
-## References
-### How to cite
-- M. Storath, A. Weinmann. [Fast median filtering for phase or orientation data.](https://doi.org/10.1109/TPAMI.2017.2692779) IEEE Transactions on Pattern Analysis and Machine Intelligence, 40(3):639-652, 2018
-### Selected user applications
-- S. Quan et al. Derivation of the Orientation Parameters in Built-Up Areas: With Application to Model-Based Decomposition. IEEE Transactions on Geoscience and Remote Sensing, 2018
-- H. Salmane et al. A method for the automated detection of solar radio bursts in dynamic spectra. J. Space Weather Space Clim. 2018
-- S. Quan et al., Derivation of the Orientation Parameters in Built-Up Areas: With Application to Model-Based Decomposition. IEEE Transactions on Geoscience and Remote Sensing. 2018
-- B. Guo, J. Wen, Y. Han. Deep Material Recognition in Light-Fields via Disentanglement of Spatial and Angular Information. ECCV 2020
+If you use this software, please cite the paper above. GitHub's "Cite this repository" button on the repo page reads the `version` and `date-released` fields from [`CITATION.cff`](CITATION.cff) and renders BibTeX/APA.
+
+## Selected user applications
+
+- S. Quan et al. *Derivation of the orientation parameters in built-up areas: with application to model-based decomposition.* IEEE Transactions on Geoscience and Remote Sensing, 2018.
+- H. Salmane et al. *A method for the automated detection of solar radio bursts in dynamic spectra.* J. Space Weather Space Clim. 2018.
+- B. Guo, J. Wen, Y. Han. *Deep material recognition in light-fields via disentanglement of spatial and angular information.* ECCV 2020.
+
+## See also
+
+Sibling projects from the same research program on variational methods for signal and image processing:
+
+- [Pottslab](https://github.com/mstorath/Pottslab) — multilabel image segmentation via the Potts / piecewise-constant Mumford-Shah model
+- [L1TV](https://github.com/mstorath/L1TV) — exact L1-TV regularisation of real- or circle-valued signals
+- [CSSD](https://github.com/mstorath/CSSD) — cubic smoothing splines for signals with discontinuities
+- [MumfordShah2D](https://github.com/mstorath/MumfordShah2D) — edge-preserving image restoration via the Mumford-Shah model
+- [DCEBE](https://github.com/mstorath/DCEBE) — bolus arrival time estimation for DCE-MRI signals
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ where d denotes the arc distance length of two angles, and r, t are the horizont
 pip install pycirclemedianfilter
 ```
 
-**Important:** The underlying implementation expects *column-major order* arrays — convert with `data = np.asfortranarray(data)` if necessary before calling the filter function. See [`demos_python/`](demos_python/) for examples.
+Input arrays are accepted in either C-order or Fortran-order (since v0.1.7 the binding auto-converts as needed). Outputs are Fortran-strided. See [`demos_python/`](demos_python/) for examples.
 
 ### MATLAB
 

--- a/demos_python/CMF_demoQuantized.py
+++ b/demos_python/CMF_demoQuantized.py
@@ -35,9 +35,6 @@ def main():
     # Data is recorded every 10 minutes; one day has 24*6 = 144 samples.
     T = 24 * 6 + 1
     R = 1  # Since the data is 1D
-    
-    # Convert the data to Fortran order (column-major) for compatibility with the C++ code.
-    windDir2Pi = np.asfortranarray(windDir2Pi)
 
     # the data has to be in the second dimension for compatibility with the C++ code
     windDir2Pi_reshaped = windDir2Pi.reshape((1, windDir2Pi.size))

--- a/demos_python/CMF_demoUnquantized.py
+++ b/demos_python/CMF_demoUnquantized.py
@@ -42,9 +42,6 @@ def main():
     
     # Set filter size (R is used for both dimensions, so here T=R)
     R = 3
-    
-    # Convert the image to Fortran order (column-major) for compatibility with the C++ code
-    img2pi = np.asfortranarray(img2pi)
 
     # Apply the circle-median filter and measure execution time.
     start_time = time.time()


### PR DESCRIPTION
## Summary

Part of the cross-repo README harmonisation pass (Pass F), plus two follow-on cleanups for stale `np.asfortranarray()` plumbing.

Three commits on this branch:

1. **Harmonise README** — add badge block (PyPI / Python / License / MATLAB / File Exchange), hero image moved to top, Quickstart section with Python / MATLAB / C++ subsections, applications and runtime preserved, "See also" standardised, License footer.
2. **Drop stale column-major warning** — the binding was actually fixed in v0.1.7 to auto-convert non-Fortran-contiguous inputs (see `filters/CMF_python_bindings.cpp:19-21` and `tests_py/test_smoke.py::test_default_c_order_input_accepted`). The README warning telling users to call `np.asfortranarray()` was therefore wrong from v0.1.7 onwards.
3. **Drop stale demo plumbing** — `demos_python/CMF_demoUnquantized.py` and `demos_python/CMF_demoQuantized.py` still called `np.asfortranarray()` with "for compatibility with the C++ code" comments. Both are no-ops now and the comments perpetuated the misconception. Comment + call removed; algorithm-relevant lines untouched.

## Test plan
- [ ] Render preview looks correct
- [ ] Demos still run end-to-end (`CMF_demoUnquantized.py`, `CMF_demoQuantized.py`)
- [ ] Badges resolve once package is on PyPI