### PR TITLE
Bump to v1.0.0 (first stable release; metadata maintenance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ documented here. This project follows
 
 ## [Unreleased]
 
+## 1.0.0 — 2026-05-11 (first stable release)
+
+Promoted from 0.1.7 to 1.0.0 as part of the lab-wide maintenance cycle.
+The C++ algorithms have been stable since 2017; the Python bindings have
+been published since 2025-02; the public API (`medfilt_circ2d`,
+`medfilt_circ2d_quant`) is unchanged. 1.0.0 signals API stability.
+
 ### Changed
 
-- **CI now auto-creates a GitHub Release on every `v*` tag push** in
-  addition to publishing to PyPI. The publish job extracts the matching
-  `## <version>` section from `CHANGELOG.md` as the release body and
-  attaches all wheels and the sdist as assets. v0.1.7's release entry
-  was created retroactively via `gh release create`.
+- Released as 1.0.0 (was 0.1.7).
+- README rewritten and harmonised with the lab-repo family (badge block, Quickstart-first ordering, "See also" section linking the five sibling repos, License footer).
+- **Stale column-major-order warning dropped** from the README and demo scripts. The binding was actually fixed in v0.1.7 to auto-convert non-Fortran-contiguous inputs, but the README still told users to call `np.asfortranarray()` themselves and the two demo scripts perpetuated the misconception. README, `demos_python/CMF_demoUnquantized.py`, and `demos_python/CMF_demoQuantized.py` now reflect the actual binding behaviour.
+- **CI now auto-creates a GitHub Release on every `v*` tag push** in addition to publishing to PyPI. The publish job extracts the matching `## <version>` section from `CHANGELOG.md` as the release body and attaches all wheels and the sdist as assets. v0.1.7's release entry was created retroactively via `gh release create`.
 
 ## 0.1.7 — 2026-05-07 (maintenance)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite both the software and the associated paper below."
 title: "Circle Median Filter: Fast median filtering for phase or orientation data"
-version: 0.1.7
-date-released: 2026-05-07
+version: 1.0.0
+date-released: 2026-05-11
 abstract: "Reference implementation (C++ with MATLAB wrappers and Python bindings) of fast algorithms for arc-distance median filtering of signals and images whose values lie on the unit circle, e.g. phase data, interferometric SAR images, wind directions, or optical-flow orientations."
 type: software
 url: "https://github.com/mstorath/CircleMedianFilter"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "pycirclemedianfilter"
 # `pycirclemedianfilter` v0.1.6 on 2025-02-18 and renaming would require a
 # deprecation cycle. Sibling repos in the variational-methods family use
 # flat names (`pottslab`, `mumfordshah2d`, …); this is the family outlier.
-version = "0.1.7"
+version = "1.0.0"
 description = "Fast median filtering for circle-valued (phase / orientation) data — Python bindings for the C++ reference implementation"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

Phase 3 maintenance release for pycirclemedianfilter — promotes from `0.1.7` to **`1.0.0`** to signal API stability. No algorithmic changes; the public C++ filtering algorithms have been stable since 2017 and the Python bindings (`medfilt_circ2d`, `medfilt_circ2d_quant`) are unchanged.

Aligns all release-version surfaces:

- `pyproject.toml::version` → `1.0.0` (was 0.1.7)
- `CITATION.cff` → `version: 1.0.0`, `date-released: 2026-05-11`
- `CHANGELOG.md` → new `## 1.0.0 — 2026-05-11 (first stable release)` entry

## What landed in this version

- README rewritten and harmonised (Pass F).
- Stale column-major-order warning dropped from README and demo scripts — the binding was actually fixed in v0.1.7 to auto-convert non-Fortran-contiguous inputs, but the README and demos still told users to call `np.asfortranarray()` themselves.
- Auto-create GitHub Release on tag push wired up.
- `CITATION.cff` version/date-released fields populated (Pass A).

## After merge

Tag `v1.0.0` on the merge commit and push the tag. The auto-release workflow handles PyPI publish + GitHub Release creation.

## Test plan
- [ ] Release workflow runs to completion on tag push
- [ ] PyPI shows `pycirclemedianfilter 1.0.0` with the harmonised README rendering correctly
- [ ] Demos still run end-to-end without the (now-removed) `np.asfortranarray()` plumbing