### PR TITLE
Bump trove classifier to Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
     "variational-methods",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary

`pyproject.toml` still declared `Development Status :: 4 - Beta` despite v1.0.0 being labelled the first stable release. Bumped to `5 - Production/Stable` so the PyPI page and trove search reflect reality.

## Test plan
- [ ] PyPI page for the next release shows the "Production/Stable" badge.